### PR TITLE
Remove having the sleep activity checked by default

### DIFF
--- a/xml/TimeUse.xml
+++ b/xml/TimeUse.xml
@@ -110,7 +110,6 @@
               </property>
             </properties>
           <!-- default option -->
-          <default>0</default>
           <skippable>false</skippable>
           <skipLabel>Skip</skipLabel>
         </prompt>


### PR DESCRIPTION
Currently, the XML has the `sleep` activity check marked by default. This commit unchecks it.